### PR TITLE
Update README example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,7 @@ Next, initialize the I2C bus object:
 .. code-block:: python
 
     import board
-    i2c_bus = busio.I2C(board.SCL, board.SCL, frequency=100000)
+    i2c_bus = busio.I2C(board.SCL, board.SDA frequency=100000)
 
 Since we have the I2C bus object, we can now use it to instantiate the SGP30 object:
 


### PR DESCRIPTION
I was struggling with the example, then I realized that busio.I2C has the following signature: `busio.I2C(scl, sda, *, frequency=400000)`.