### PR TITLE
Add helper method to set IAQ humidity

### DIFF
--- a/adafruit_sgp30.py
+++ b/adafruit_sgp30.py
@@ -25,6 +25,7 @@ Implementation Notes
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
 import time
+from math import exp
 from adafruit_bus_device.i2c_device import I2CDevice
 from micropython import const
 
@@ -167,6 +168,20 @@ class Adafruit_SGP30:
             arr.append(self._generate_crc(arr))
             buffer += arr
         self._run_profile(["iaq_set_humidity", [0x20, 0x61] + buffer, 0, 0.01])
+
+    def set_iaq_relative_humidity(self, celcius, relative_humidity):
+        """
+        Set the humidity in g/m3 for eCo2 and TVOC compensation algorithm.
+        The absolute humidity is calculated from the temperature and relative
+        humidity (as a percentage).
+        """
+        numerator = ((relative_humidity / 100) * 6.112) * exp(
+            (17.62 * celcius) / (243.12 + celcius)
+        )
+        denominator = 273.15 + celcius
+
+        humidity_grams_pm3 = 216.7 * (numerator / denominator)
+        self.set_iaq_humidity(humidity_grams_pm3)
 
     # Low level command functions
 

--- a/examples/sgp30_simpletest.py
+++ b/examples/sgp30_simpletest.py
@@ -17,6 +17,7 @@ print("SGP30 serial #", [hex(i) for i in sgp30.serial])
 
 sgp30.iaq_init()
 sgp30.set_iaq_baseline(0x8973, 0x8AAE)
+sgp30.set_iaq_relative_humidity(celcius=22.1, relative_humidity=44)
 
 elapsed_sec = 0
 


### PR DESCRIPTION
Most sensors only report relative humidity and temperature, so this
uses the formula in the datasheet [^1] to make calibration easier.

Notes:

- The datasheet doesn't give the origin of the formula, but it seems
to be based on Tetens Equation (to approximate pressure).

- The example in the datasheet is wrong: the output should be 11.48.

- math.exp is available in MicroPython [^2].

[^1]: https://sensirion.com/media/documents/984E0DD5/61644B8B/Sensirion_Gas_Sensors_Datasheet_SGP30.pdf
[^2]: https://docs.micropython.org/en/latest/library/math.html#math.exp