### PR TITLE
fix Celsius spelling

### DIFF
--- a/adafruit_sgp30.py
+++ b/adafruit_sgp30.py
@@ -169,16 +169,16 @@ class Adafruit_SGP30:
             buffer += arr
         self._run_profile(["iaq_set_humidity", [0x20, 0x61] + buffer, 0, 0.01])
 
-    def set_iaq_relative_humidity(self, celcius, relative_humidity):
+    def set_iaq_relative_humidity(self, celsius, relative_humidity):
         """
         Set the humidity in g/m3 for eCo2 and TVOC compensation algorithm.
-        The absolute humidity is calculated from the temperature and relative
-        humidity (as a percentage).
+        The absolute humidity is calculated from the temperature (Celsius)
+        and relative humidity (as a percentage).
         """
         numerator = ((relative_humidity / 100) * 6.112) * exp(
-            (17.62 * celcius) / (243.12 + celcius)
+            (17.62 * celsius) / (243.12 + celsius)
         )
-        denominator = 273.15 + celcius
+        denominator = 273.15 + celsius
 
         humidity_grams_pm3 = 216.7 * (numerator / denominator)
         self.set_iaq_humidity(humidity_grams_pm3)


### PR DESCRIPTION
This change fixes spelling of the Celsius.

This will break pre-existing code such as:
```python
   sgp30_sensor.set_iaq_relative_humidity(
            celcius=temp_celsius, relative_humidity=relative_humidity
        )
```
however will be easier on the eyes :-)