### PR TITLE
iaq_init() already called from Adafruit_SGP30()

### DIFF
--- a/examples/sgp30_simpletest.py
+++ b/examples/sgp30_simpletest.py
@@ -15,7 +15,6 @@ sgp30 = adafruit_sgp30.Adafruit_SGP30(i2c)
 
 print("SGP30 serial #", [hex(i) for i in sgp30.serial])
 
-sgp30.iaq_init()
 sgp30.set_iaq_baseline(0x8973, 0x8AAE)
 sgp30.set_iaq_relative_humidity(celcius=22.1, relative_humidity=44)
 


### PR DESCRIPTION
The `iaq_init()` does not have to be called explicitly since it is already called from `Adafruit_SGP30()`:
https://github.com/adafruit/Adafruit_CircuitPython_SGP30/blob/06e752cd03d3a7ed13a54f76cdd984b5b922b676/adafruit_sgp30.py#L93